### PR TITLE
Ensured package id update is called early enough

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,5 +20,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 - Fixed error when attempting to write the WASM version
+- Fixed issue where Android application id is changed too late in the build process
 
 ### Security

--- a/src/Application.Packaging/Targets/Android.targets
+++ b/src/Application.Packaging/Targets/Android.targets
@@ -13,7 +13,7 @@
 	</Target>
 
 	<Target Name="_UpdatePackageId"
-			BeforeTargets="BeforeBuild"
+			BeforeTargets="StartAndroidActivity"
 			Condition="'$(AndroidApplication)' == 'true' and '$(ApplicationIdentifier)' != ''">
 
 		<PropertyGroup>


### PR DESCRIPTION
GitHub Issue: #
<!-- Link to relevant GitHub issue if applicable.
     All PRs should be associated with an issue -->

## Proposed Changes
<!-- Please un-comment one ore more that apply to this PR -->

- Bug fix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other, please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying,
     or link to a relevant issue. -->
Application id is changed in the files but the manifest has already been loaded by Xamarin, causing the resulting AAB to have the old application id

## What is the new behavior?
<!-- Please describe the new behavior after your modifications. -->
Application is changed before the target that loads the manifest

## Checklist

Please check if your PR fulfills the following requirements:

- [ ] Documentation has been added/updated
- [ ] Automated Unit / Integration tests for the changes have been added/updated
- [ ] Contains **NO** breaking changes
- [ ] Updated the Changelog
- [ ] Associated with an issue

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->


## Other information
<!-- Please provide any additional information if necessary -->

