### PR TITLE
Ensured package id is updated at the right time

### DIFF
--- a/src/Application.Packaging/Targets/Android.targets
+++ b/src/Application.Packaging/Targets/Android.targets
@@ -12,8 +12,10 @@
 			  DestinationFolder="$(PackageOutputPath)" />
 	</Target>
 
+	 <!-- _ValidateAndroidPackageProperties fetches the packagd id from the manifest and stores it in a variable used throughout the build -->
+	 <!-- The id must be changed before this happens -->
 	<Target Name="_UpdatePackageId"
-			BeforeTargets="_ResolveSdks"
+			BeforeTargets="_ValidateAndroidPackageProperties"
 			Condition="'$(AndroidApplication)' == 'true' and '$(ApplicationIdentifier)' != ''">
 
 		<PropertyGroup>


### PR DESCRIPTION
GitHub Issue: #
<!-- Link to relevant GitHub issue if applicable.
     All PRs should be associated with an issue -->

## Proposed Changes
<!-- Please un-comment one ore more that apply to this PR -->

- Bug fix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other, please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying,
     or link to a relevant issue. -->
Android package id is updated too late in the build process, causing it not to be used in the final package

## What is the new behavior?
<!-- Please describe the new behavior after your modifications. -->
Android package id is updated before Xamarin fetches it from the manifest

## Checklist

Please check if your PR fulfills the following requirements:

- [ ] Documentation has been added/updated
- [ ] Automated Unit / Integration tests for the changes have been added/updated
- [ ] Contains **NO** breaking changes
- [ ] Updated the Changelog
- [ ] Associated with an issue

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->


## Other information
<!-- Please provide any additional information if necessary -->

