### PR TITLE
Changed the way the application manifest is found

### DIFF
--- a/src/Application.Packaging/Targets/Android.targets
+++ b/src/Application.Packaging/Targets/Android.targets
@@ -21,7 +21,7 @@
 		<PropertyGroup>
 			<!-- _AndroidManifestAbs contains the location of the Android manifest -->
 			<!-- Set by Xamarin Android : https://github.com/xamarin/xamarin-android/blob/a2a76c337705b1a24ee45a0fe979d24319e3bee3/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets#L691 -->
-			<_ApplicationManifestPath>$(_AndroidManifestAbs)</_ApplicationManifestPath>
+			<_ApplicationManifestPath>$(ProjectDir)$(AndroidManifest)</_ApplicationManifestPath>
 		</PropertyGroup>
 
 		<Warning Condition="!Exists('$(_ApplicationManifestPath)')"


### PR DESCRIPTION
GitHub Issue: #
<!-- Link to relevant GitHub issue if applicable.
     All PRs should be associated with an issue -->

## Proposed Changes
<!-- Please un-comment one ore more that apply to this PR -->

- Bug fix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other, please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying,
     or link to a relevant issue. -->
Manifest is found using a variable set in the following target

## What is the new behavior?
<!-- Please describe the new behavior after your modifications. -->
Manifest is found using available variables

## Checklist

Please check if your PR fulfills the following requirements:

- [ ] Documentation has been added/updated
- [ ] Automated Unit / Integration tests for the changes have been added/updated
- [ ] Contains **NO** breaking changes
- [ ] Updated the Changelog
- [ ] Associated with an issue

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->


## Other information
<!-- Please provide any additional information if necessary -->

