### PR TITLE
Moved _SetApplicationVersion earlier

### DIFF
--- a/src/Application.Versioning/Targets/iOS.targets
+++ b/src/Application.Versioning/Targets/iOS.targets
@@ -1,6 +1,6 @@
 <Project>
 	<Target Name="_SetApplicationVersion"
-			BeforeTargets="BeforeBuild"
+			BeforeTargets="_DetectAppManifest"
 			DependsOnTargets="_CalculateApplicationVersion"
 			Condition="'$(BuildingInsideVisualStudio)'=='' and '$(ApplicationVersion)'!=''">
 		<PropertyGroup>


### PR DESCRIPTION
This ensures it is called early enough in the build process

GitHub Issue: #
<!-- Link to relevant GitHub issue if applicable.
     All PRs should be associated with an issue -->

## Proposed Changes
<!-- Please un-comment one ore more that apply to this PR -->

- Bug fix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other, please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying,
     or link to a relevant issue. -->
Version is set too late in iOS

## What is the new behavior?
<!-- Please describe the new behavior after your modifications. -->
Version is set earlier

## Checklist

Please check if your PR fulfills the following requirements:

- [ ] Documentation has been added/updated
- [ ] Automated Unit / Integration tests for the changes have been added/updated
- [ ] Contains **NO** breaking changes
- [ ] Updated the Changelog
- [ ] Associated with an issue

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->


## Other information
<!-- Please provide any additional information if necessary -->

