### PR TITLE
fix: fixed broken Android package name change

### DIFF
--- a/src/Application.Packaging/Targets/Android.targets
+++ b/src/Application.Packaging/Targets/Android.targets
@@ -15,7 +15,7 @@
 	 <!-- _ValidateAndroidPackageProperties fetches the packagd id from the manifest and stores it in a variable used throughout the build -->
 	 <!-- The id must be changed before this happens -->
 	<Target Name="_UpdatePackageId"
-			BeforeTargets="_ValidateAndroidPackageProperties"
+			BeforeTargets="_ValidateAndroidPackageProperties;_GetAndroidPackageName"
 			Condition="'$(AndroidApplication)' == 'true' and '$(ApplicationIdentifier)' != ''">
 
 		<PropertyGroup>


### PR DESCRIPTION
GitHub Issue: #
<!-- Link to relevant GitHub issue if applicable.
     All PRs should be associated with an issue -->

## Proposed Changes
<!-- Please un-comment one ore more that apply to this PR -->

- Bug fix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other, please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying,
     or link to a relevant issue. -->
In the latest versions of Xamarin Android, `_ValidateAndroidPackageProperties` used to be the target in which the application identifier variable used by Xamarin was set. Since [a specific commit](https://github.com/xamarin/xamarin-android/commit/4f74bab0ab7be4627bd4588909ffb35da9a9653b), a new target has been created to handle that part and is now run before the other one, causing the change made by Nimue to be ignored partially by Xamarin, and causing the application identifier to be changed only in the resulting file name.

## What is the new behavior?
<!-- Please describe the new behavior after your modifications. -->
The target used to update the application identifier is now run before the new `_GetAndroidPackageName`, causing the application identifier to be properly updated.


## Checklist

Please check if your PR fulfills the following requirements:

- [ ] Documentation has been added/updated
- [ ] Automated Unit / Integration tests for the changes have been added/updated
- [ ] Contains **NO** breaking changes
- [ ] Updated the Changelog
- [ ] Associated with an issue

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->


## Other information
<!-- Please provide any additional information if necessary -->

